### PR TITLE
SWC-18827 fix: resolve GHSA-m557-wrgg-6rp4 (composer.lock only)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5338,16 +5338,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.52",
+            "version": "3.0.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
+                "reference": "db9744e6d47e742b1f974e965ad49bdd041105af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/db9744e6d47e742b1f974e965ad49bdd041105af",
+                "reference": "db9744e6d47e742b1f974e965ad49bdd041105af",
                 "shasum": ""
             },
             "require": {
@@ -5428,7 +5428,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.55"
             },
             "funding": [
                 {
@@ -5444,7 +5444,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-27T07:02:15+00:00"
+            "time": "2026-06-14T23:24:10+00:00"
         },
         {
             "name": "predis/predis",


### PR DESCRIPTION
## Summary
Resolves **GHSA-m557-wrgg-6rp4** by updating `composer.lock` only (transitive dependency `phpseclib/phpseclib` bumped 3.0.52 → 3.0.55 — `composer.json` unchanged).

## Changes
- `composer.lock`: bumped vulnerable transitive dependency to fixed version

## Note
This repo's `composer.lock` already pins `cakephp/chronos` 2.5.2, which declares a PHP >=8.4 requirement that the rest of the dependency graph (PHP ^8.1) doesn't satisfy. This pre-existing inconsistency is invisible in production because the Dockerfile uses `composer install` (no re-resolution), but it blocks a plain `composer update` for any package. This PR's lockfile update required `--ignore-platform-req=php` to work around that unrelated, pre-existing issue — no PHP version constraints were changed and production install behavior is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)